### PR TITLE
Added slack integration

### DIFF
--- a/api/rps/urls.py
+++ b/api/rps/urls.py
@@ -3,5 +3,6 @@ from django.urls import include, path
 
 urlpatterns = [
     path("api/admin/", admin.site.urls),
+    path("api/slack/", include("slack.urls")),
     path("api/", include("core.urls")),
 ]

--- a/api/slack/apps.py
+++ b/api/slack/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class SlackConfig(AppConfig):
+    name = "slack"

--- a/api/slack/urls.py
+++ b/api/slack/urls.py
@@ -1,0 +1,7 @@
+from django.urls import include, path
+
+from . import views
+
+urlpatterns = [
+    path("", views.SlackIntegrationView.as_view()),
+]

--- a/api/slack/views.py
+++ b/api/slack/views.py
@@ -1,0 +1,23 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+
+from core.util import get_livematch_id
+
+
+class SlackIntegrationView(APIView):
+    permission_classes = []  # This API view doesn't need to check CSRF
+
+    def post(self, request, *args, **kwargs):
+        """
+        For now there is only one type of slack integration, which is to generate a new match.
+
+        In the future if we include more workflow like `/rps leaderboard`,
+        we can parse the message here and return different type of responses.
+        """
+        return Response({
+            'response_type': 'in_channel',
+            'text': request.build_absolute_uri('/matches/live/{}'.format(get_livematch_id())),
+            'attachments': [{
+                'text': 'Let the battle begin!'
+            }]
+        })


### PR DESCRIPTION
Added a slack app to contain the logic around slack integration. Right now, starting a new game is supported.
A sample response when you post to the new endpoint looks like:
{
  "response_type": "in_channel",
  "text": "http://localhost:8000/matches/live/472a859",
  "attachments": [
    {
      "text": "Let the battle begin!"
    }
  ]
}